### PR TITLE
fix: 补充 getTabBar 在 Page 中的定义, 并修改为可选类型

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@
 * Page
     * [x] this.setData() 无需感叹号，强类型验证
     * [x] this.route 无感叹号
+    * [x] 补充 this.getTabBar() 支持 (含类型安全检查、泛型参数)
 * Component
     * [x] properties 完整定义支持和类型绑定
     * [x] data 绑定 properties 数据
     * [x] observer/observers this 绑定(支持data/properties/methods调用)
     * [x] lifetimes/pageLifetimes/relations/methods 完整this绑定(支持data/properties/methods调用)
     * [x] setData 强类型校验和自动提示
+    * [x] this.getTabBar() 支持类型安全检查、泛型参数
 Fixed 错误定义
 * [x] fix wx.AuthSetting 类型错误
 * [x] fix chooseimage

--- a/test/page.test.ts
+++ b/test/page.test.ts
@@ -27,8 +27,8 @@ Page({
     },
     onReady() {
         if (this.getTabBar) {
-            const tabbar = this.getTabBar()
-            tabbar.setData({active: 1})
+            const tabbar = this.getTabBar<{active: number}>()
+            tabbar.setData({ active: 1 })
         }
     },
     tapOnBtn(){

--- a/test/page.test.ts
+++ b/test/page.test.ts
@@ -25,6 +25,12 @@ Page({
         this.route;
         this.extend.k = this.data.o.s
     },
+    onReady() {
+        if (this.getTabBar) {
+            const tabbar = this.getTabBar()
+            tabbar.setData({active: 1})
+        }
+    },
     tapOnBtn(){
         this.onLoad()
     },

--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -22,18 +22,18 @@ declare interface WxComponent<TProp, TData, TMethod> {
   is: string;
   /** 节点id */
   id: string;
-  /** 
-   * 节点dataset 
+  /**
+   * 节点dataset
    */
   dataset: Record<string, any>;
 
   properties: Readonly<TProp>;
-  /** 
-   * 组件的内部数据，和 `properties` 一同用于组件的模板渲染 
+  /**
+   * 组件的内部数据，和 `properties` 一同用于组件的模板渲染
    */
   data: Readonly<TData & TProp>;
 
-  /** 
+  /**
    * 设置data并执行视图层渲染
    */
   setData(
@@ -66,23 +66,23 @@ declare interface WxComponent<TProp, TData, TMethod> {
   /** 立刻执行 callback ，其中的多个 setData 之间不会触发界面绘制（只有某些特殊场景中需要，如用于在不同组件同时 setData 时进行界面绘制同步）*/
   groupSetData(callback?: () => void): void;
   /** 返回当前页面的 custom-tab-bar 的组件实例 */
-  getTabBar(): WxComponent<any, any, any>;
+  getTabBar?(): WxComponent<any, any, any>;
 }
 
 declare interface TriggerEventOption {
-  /** 
+  /**
    * 事件是否冒泡
    *
    * 默认值： `false`
    */
   bubbles?: boolean;
-  /** 
+  /**
    * 事件是否可以穿越组件边界，为false时，事件将只能在引用组件的节点树上触发，不进入其他任何组件内部
    *
    * 默认值： `false`
    */
   composed?: boolean;
-  /** 
+  /**
    * 事件是否拥有捕获阶段
    *
    * 默认值： `false`
@@ -155,34 +155,34 @@ interface BaseComponet<TProp, TData, TMethod extends Record<string, Function>> {
   */
   properties?: RecordPropsDefinition<TProp> & ThisComponent<TProp, TData, TMethod>,
 
-  /** 
-   * 组件的内部数据，和 `properties` 一同用于组件的模板渲染 
+  /**
+   * 组件的内部数据，和 `properties` 一同用于组件的模板渲染
    */
   data?: TData
-  /** 
-   * 组件数据字段监听器，用于监听 properties 和 data 的变化 
+  /**
+   * 组件数据字段监听器，用于监听 properties 和 data 的变化
    */
   observers?: Record<string, Function> & ThisComponent<TProp, TData, TMethod>;
-  /** 
-   * object组件的方法，包括事件响应函数和任意的自定义方法，关于事件响应函数的使用，参见 [组件事件](events.md) 
+  /**
+   * object组件的方法，包括事件响应函数和任意的自定义方法，关于事件响应函数的使用，参见 [组件事件](events.md)
    */
   methods?: TMethod & ThisComponent<TProp, TData, TMethod>,
-  /** 
+  /**
    * 组件间关系定义，参见 [组件间关系](relations.md)
    */
   relations?: {
     [componentName: string]: RelationOption & ThisComponent<TProp, TData, TMethod>;
   };
 
-  /** 
+  /**
    * 组件接受的外部样式类，参见 [外部样式类](wxml-wxss.md)
    */
   externalClasses?: string[];
-  /** 
-   * 一些选项（文档中介绍相关特性时会涉及具体的选项设置，这里暂不列举） 
+  /**
+   * 一些选项（文档中介绍相关特性时会涉及具体的选项设置，这里暂不列举）
    */
   options?: ComponentOptions;
-  /** 
+  /**
    * 组件生命周期声明对象，组件的生命周期：`created`、`attached`、`ready`、`moved`、`detached` 将收归到 `lifetimes` 字段内进行声明，原有声明方式仍旧有效，如同时存在两种声明方式，则 `lifetimes` 字段内声明方式优先级最高
    *
    * 最低基础库： `2.2.3`
@@ -190,15 +190,15 @@ interface BaseComponet<TProp, TData, TMethod extends Record<string, Function>> {
   lifetimes?: ComponentLifetimes & ThisComponent<TProp, TData, TMethod>;
   /** 组件所在页面的生命周期声明对象，目前仅支持页面的 `show` 和 `hide` 两个生命周期
    *
-   * 最低基础库： `2.2.3` 
+   * 最低基础库： `2.2.3`
    */
   pageLifetimes?: PageLifetimes & ThisComponent<TProp, TData, TMethod>;
 
   behaviors?: string[],
-  /** 
+  /**
    * 定义段过滤器，用于自定义组件扩展，参见 [自定义组件扩展](extend.md)
    *
-   * 最低基础库： `2.2.3` 
+   * 最低基础库： `2.2.3`
    */
   definitionFilter?: DefinitionFilter<ThisComponent<TProp, TData, TMethod>>;
 }

--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -66,7 +66,7 @@ declare interface WxComponent<TProp, TData, TMethod> {
   /** 立刻执行 callback ，其中的多个 setData 之间不会触发界面绘制（只有某些特殊场景中需要，如用于在不同组件同时 setData 时进行界面绘制同步）*/
   groupSetData(callback?: () => void): void;
   /** 返回当前页面的 custom-tab-bar 的组件实例 */
-  getTabBar?(): WxComponent<any, any, any>;
+  getTabBar?<TD = any, TM = any, TP = {}>(): WxComponent<TP, TD, TM>;
 }
 
 declare interface TriggerEventOption {

--- a/types/wx/lib.wx.page.d.ts
+++ b/types/wx/lib.wx.page.d.ts
@@ -17,7 +17,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 /* tslint:disable: no-unnecessary-generics jsdoc-format interface-name */
 
 /*! *****************************************************************************
-Copyright (c) 2018 Tencent, Inc. All rights reserved. 
+Copyright (c) 2018 Tencent, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -116,6 +116,9 @@ declare namespace Page {
 
     /** 到当前页面的路径，类型为`String`。最低基础库： `1.2.0` */
     route: string;
+
+    /** 返回当前页面的 custom-tab-bar 的组件实例 */
+    getTabBar?(): WxComponent<any, any, any>
   }
 
   interface PageOptions<
@@ -146,10 +149,10 @@ declare namespace Page {
      */
     onShow?(): void;
     /** 生命周期回调—监听页面初次渲染完成
-     * 
+     *
      * 页面初次渲染完成时触发。一个页面只会调用一次，代表页面已经准备妥当，可以和视图层进行交互。
-     * 
-   
+     *
+
      * 注意：对界面内容进行设置的 API 如`wx.setNavigationBarTitle`，请在`onReady`之后进行。
     */
     onReady?(): void;

--- a/types/wx/lib.wx.page.d.ts
+++ b/types/wx/lib.wx.page.d.ts
@@ -118,7 +118,7 @@ declare namespace Page {
     route: string;
 
     /** 返回当前页面的 custom-tab-bar 的组件实例 */
-    getTabBar?(): WxComponent<any, any, any>
+    getTabBar?<TD = any, TM = any, TP = {}>(): WxComponent<TP, TD, TM>;
   }
 
   interface PageOptions<


### PR DESCRIPTION
修复自用时的一些问题

- **修改了 `lib.wx.component.d.ts` 的 `getTabBar` 类型, 使其可选**
  因为 app.json 中如果没有定义当前页面为 tabbar 页的话, getTabBar 会不存在, 增加可选类型使其安全

- **在 `lib.wx.page.d.ts` 补充了 `getTabBar` 的定义**
   在 Page 中也可使用 this.getTabBar()

*ps: 感觉 getTabBar() 的返回值设置成 `/custom-tab-bar/index.ts` 的实例最好, 但是不知道怎么弄, 暂时用 unknown 或 `WxComponent<any, any, any>`*

对这个PR如果有什么好的修改建议, 希望您可以指出或直接修改 😊

> https://developers.weixin.qq.com/miniprogram/dev/framework/ability/custom-tabbar.html
