### PR TITLE
fix: 修复 getTabBar 定义错误的问题

### DIFF
--- a/test/componet.test.ts
+++ b/test/componet.test.ts
@@ -41,6 +41,8 @@ Component({
     methods: {
         KKKK() {
             this.mmm()
+            const tabbar = this.getTabBar()
+            tabbar && tabbar.setData({ active: 1 })
         },
         mmm() {
             this.dataset.x;

--- a/test/page.test.ts
+++ b/test/page.test.ts
@@ -26,8 +26,8 @@ Page({
         this.extend.k = this.data.o.s
     },
     onReady() {
-        if (this.getTabBar) {
-            const tabbar = this.getTabBar<{active: number}>()
+        const tabbar = this.getTabBar<{active: number}>()
+        if (tabbar) {
             tabbar.setData({ active: 1 })
         }
     },

--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -66,7 +66,7 @@ declare interface WxComponent<TProp, TData, TMethod> {
   /** 立刻执行 callback ，其中的多个 setData 之间不会触发界面绘制（只有某些特殊场景中需要，如用于在不同组件同时 setData 时进行界面绘制同步）*/
   groupSetData(callback?: () => void): void;
   /** 返回当前页面的 custom-tab-bar 的组件实例 */
-  getTabBar?<TD = any, TM = any, TP = {}>(): WxComponent<TP, TD, TM>;
+  getTabBar<TD = any, TM = any, TP = {}>(): WxComponent<TP, TD, TM> | null;
 }
 
 declare interface TriggerEventOption {

--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -65,7 +65,9 @@ declare interface WxComponent<TProp, TData, TMethod> {
   getRelationNodes(relationKey: string): WxComponent<any, any, any>[];
   /** 立刻执行 callback ，其中的多个 setData 之间不会触发界面绘制（只有某些特殊场景中需要，如用于在不同组件同时 setData 时进行界面绘制同步）*/
   groupSetData(callback?: () => void): void;
-  /** 返回当前页面的 custom-tab-bar 的组件实例 */
+  /** 返回当前页面的 custom-tab-bar 的组件实例
+   *
+   * 注意: 在基础库 < 2.5.0 时该方法可能会不存在, 需要先判断 getTabBar 方法是否存在 */
   getTabBar<TD = any, TM = any, TP = {}>(): WxComponent<TP, TD, TM> | null;
 }
 

--- a/types/wx/lib.wx.page.d.ts
+++ b/types/wx/lib.wx.page.d.ts
@@ -117,7 +117,9 @@ declare namespace Page {
     /** 到当前页面的路径，类型为`String`。最低基础库： `1.2.0` */
     route: string;
 
-    /** 返回当前页面的 custom-tab-bar 的组件实例 */
+  /** 返回当前页面的 custom-tab-bar 的组件实例
+   *
+   * 注意: 在基础库 < 2.5.0 时该方法可能会不存在, 需要先判断 getTabBar 方法是否存在 */
     getTabBar<TD = any, TM = any, TP = {}>(): WxComponent<TP, TD, TM> | null;
   }
 

--- a/types/wx/lib.wx.page.d.ts
+++ b/types/wx/lib.wx.page.d.ts
@@ -118,7 +118,7 @@ declare namespace Page {
     route: string;
 
     /** 返回当前页面的 custom-tab-bar 的组件实例 */
-    getTabBar?<TD = any, TM = any, TP = {}>(): WxComponent<TP, TD, TM>;
+    getTabBar<TD = any, TM = any, TP = {}>(): WxComponent<TP, TD, TM> | null;
   }
 
   interface PageOptions<


### PR DESCRIPTION
又经实测, `getTabBar()` 在每个组件中都可使用, 只是如果没有 `custom-tab-bar` 时会返回 `null`

修复此问题