### PR TITLE
fix: PageInstance "options" property

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 * Page
     * [x] this.setData() 无需感叹号，强类型验证
     * [x] this.route 无感叹号
+    * [x] 补充 this.options
     * [x] 补充 this.getTabBar() 支持 (含类型安全检查、泛型参数)
     * [x] Page.onLoad 支持undefined
     * [x] Page.onLoad / onShareAppMessage / onPageScroll / onResize 等参数自动绑定

--- a/test/page.test.ts
+++ b/test/page.test.ts
@@ -13,6 +13,8 @@ Page({
     onLoad() {
         this.route
         this.tapOnBtn()
+
+        getCurrentPages().map(p => p.options)
     },
     onHide() {
 

--- a/types/wx/lib.wx.page.d.ts
+++ b/types/wx/lib.wx.page.d.ts
@@ -92,6 +92,13 @@ declare namespace Page {
     */
     data: Readonly<D>;
 
+    /**
+     * 打开当前页面路径中的参数
+     *
+     * 最低基础库 `2.1.0`
+     */
+    options: Record<string, string>
+
     /** `setData` 函数用于将数据从逻辑层发送到视图层（异步），同时改变对应的 `this.data` 的值（同步）。
      *
      * **注意：**


### PR DESCRIPTION
补充 `PageInstance` 下的 `options` 属性

该属性用在
- 页面实例中, `this.options` 返回传入当前页面的参数, 如果没有参数返回空对象
- `getCurrentPages()` 方法返回的页面实例数组