### PR TITLE
fix: canvas setTextAlign / setTextBaseline restrict

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Fixed 修复官方的错误定义
 * [x] fix wx.Color 定义错误
 * [x] fix 支持 canvasContext.setFillStyle() 传入 wx.CanvasGradient 类型
 * [x] fix canvasContext.drawImage() 可选 3/5/9 个参数
+* [x] fix canvasContext setTextAlign / setTextBaseline 约束
 * [x] fix relativeToViewport()
 * [x] fix setTimeout/setInterval rest 参数
 * [x] fix innerAudio onerror/offerror callback

--- a/test/canvas.test.ts
+++ b/test/canvas.test.ts
@@ -22,6 +22,11 @@ Page({
     ctx.strokeRect(20, 198, 76, 76)
     ctx.drawImage('abc', 20, 198, 76, 76)
 
+    ctx.save()
+    ctx.setTextAlign('left')
+    ctx.setTextBaseline('top')
+    ctx.restore()
+
     ctx.draw(false, () => {
       wx.canvasToTempFilePath({
         canvasId: 'share-canvas',

--- a/types/wx/lib.wx.api.d.ts
+++ b/types/wx/lib.wx.api.d.ts
@@ -6037,7 +6037,7 @@ ctx.draw()
 * 最低基础库： `1.1.0` */
     setTextAlign(
       /** 文字的对齐方式 */
-      align: string,
+      align: 'left' | 'center' | 'right',
     ): void;
     /** [CanvasContext.setTextBaseline(string textBaseline)](CanvasContext.setTextBaseline.md)
 * 
@@ -6075,7 +6075,7 @@ ctx.draw()
 * 最低基础库： `1.4.0` */
     setTextBaseline(
       /** 文字的竖直对齐方式 */
-      textBaseline: string,
+      textBaseline: 'normal' | 'middle' | 'bottom' | 'top',
     ): void;
     /** [CanvasContext.setTransform(number scaleX, number scaleY, number skewX, number skewY, number translateX, number translateY)](CanvasContext.setTransform.md)
      *


### PR DESCRIPTION
对 `canvasContext.setTextAlign` 和 `canvasContext.setTextBaseline` 类型约束

> reference 
  [CanvasContext.setTextAlign](https://developers.weixin.qq.com/miniprogram/dev/api/canvas/CanvasContext.setTextAlign.html) 
  [CanvasContext.setTextBaseline](https://developers.weixin.qq.com/miniprogram/dev/api/canvas/CanvasContext.setTextBaseline.html)